### PR TITLE
Docs link should reference to https://docs.nil.foundation/

### DIFF
--- a/site/src/components/common/Footer/stub.ts
+++ b/site/src/components/common/Footer/stub.ts
@@ -17,7 +17,7 @@ export const stub = {
         { name: 'Research', link: '/research' },
         {
           name: 'Documentation',
-          link: 'https://docs.nil.foundation/proof-market/',
+          link: 'https://docs.nil.foundation/',
         },
         { name: 'About', link: '/about' },
         // TODO: return after create this page

--- a/site/src/components/common/Header/stub.ts
+++ b/site/src/components/common/Header/stub.ts
@@ -7,7 +7,7 @@ export const links = {
     { name: 'Blog', link: '/blog' },
     {
       name: 'Documentation',
-      link: 'https://docs.nil.foundation/proof-market/',
+      link: 'https://docs.nil.foundation/',
     },
     { name: 'Research', link: '/research' },
     { name: 'About', link: '/about' },


### PR DESCRIPTION
Right now it point to proof market docs.