### PR TITLE
Check formatting in ci

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -11,7 +11,7 @@
     "default_user": "strapi admin:create-user --firstname=Admin --lastname=Adin --email=admin@nil.foundation --password=XYgiXDOcg4Lfpv6g",
     "lint": "npx @biomejs/biome check src",
     "lint:fix": "npx @biomejs/biome check src --apply",
-    "format": "npx @biomejs/biome format src",
+    "format": "npx @biomejs/biome check src --organize-imports-enabled=false --linter-enabled=false",
     "format:fix": "npx @biomejs/biome format src --write"
   },
   "dependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "npx @biomejs/biome format src",
+    "format": "npx @biomejs/biome check src --organize-imports-enabled=false --linter-enabled=false",
     "format:fix": "npx @biomejs/biome format src --write"
   },
   "dependencies": {


### PR DESCRIPTION
This diff fixes format script.
Biome `format` doesn't throw any errors on incorrect format cases.
It is replaced with `check` command. But check command has some strange limitations now and seems to respect biome.json partially, so i needed to add some CLI arguments.