### PR TITLE
Add compatibility with old positions urls

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -18,10 +18,9 @@ const nextConfig = {
           {
             type: 'query',
             key: 'jobId',
-            value: '?<jobId>value',
           },
         ],
-        destination: '/careers/jobs/value',
+        destination: '/careers/jobs/:jobId',
         permanent: true,
       },
     ];

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -13,18 +13,18 @@ const nextConfig = {
   redirects: async () => {
     return [
       {
-        source: '/careers/jobs',
+        source: '/careers/jobs/',
+        destination: '/careers/jobs/:jobId',
         has: [
           {
             type: 'query',
             key: 'jobId',
           },
         ],
-        destination: '/careers/jobs/:jobId',
-        permanent: true,
-      },
+        permanent: false,
+      }
     ];
-  },
+  }
 };
 
 module.exports = nextConfig;

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -9,6 +9,23 @@ const nextConfig = {
   webpack: config => {
     return config;
   },
+
+  redirects: async () => {
+    return [
+      {
+        source: '/careers/jobs',
+        has: [
+          {
+            type: 'query',
+            key: 'jobId',
+            value: '?<jobId>value',
+          },
+        ],
+        destination: '/careers/jobs/value',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hotjar/browser": "^1.0.9",
-        "@nilfoundation/ui-kit": "^2.2.6",
+        "@nilfoundation/ui-kit": "^2.2.8",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "axios": "^1.4.0",
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@nilfoundation/ui-kit": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nilfoundation/ui-kit/-/ui-kit-2.2.6.tgz",
-      "integrity": "sha512-U4VMrEp5GkWv1DXTRQRMUgk7xjrxHGT/9UbcPwI4Vxy7G6wXSRWaAO429A28/Csgq97iu80PgpbHseBlZ1GysQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@nilfoundation/ui-kit/-/ui-kit-2.2.8.tgz",
+      "integrity": "sha512-p8a3ZYU7VzbGtLtqtujno1Eohjcaseh+F71D905q5c7DnTR7QkVjiEgQTkK7eXzbPc3lahhUM7lH3Y+6QsS/fA==",
       "dependencies": {
         "copy-to-clipboard": "^3.3.3",
         "inline-style-expand-shorthand": "^1.6.0",
@@ -8877,9 +8877,9 @@
       "optional": true
     },
     "@nilfoundation/ui-kit": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@nilfoundation/ui-kit/-/ui-kit-2.2.6.tgz",
-      "integrity": "sha512-U4VMrEp5GkWv1DXTRQRMUgk7xjrxHGT/9UbcPwI4Vxy7G6wXSRWaAO429A28/Csgq97iu80PgpbHseBlZ1GysQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@nilfoundation/ui-kit/-/ui-kit-2.2.8.tgz",
+      "integrity": "sha512-p8a3ZYU7VzbGtLtqtujno1Eohjcaseh+F71D905q5c7DnTR7QkVjiEgQTkK7eXzbPc3lahhUM7lH3Y+6QsS/fA==",
       "requires": {
         "copy-to-clipboard": "^3.3.3",
         "inline-style-expand-shorthand": "^1.6.0",

--- a/site/package.json
+++ b/site/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hotjar/browser": "^1.0.9",
-    "@nilfoundation/ui-kit": "^2.2.6",
+    "@nilfoundation/ui-kit": "^2.2.8",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "axios": "^1.4.0",

--- a/site/src/components/pages/OpenPositions/OpenPositions.tsx
+++ b/site/src/components/pages/OpenPositions/OpenPositions.tsx
@@ -8,7 +8,7 @@ import Icon from 'components/Icon'
 
 import s from './OpenPositions.module.scss'
 import DottedSection from './DottedSection'
-import { UIPosition } from 'src/freshteam/types'
+import { UIPositionWithoutDescription } from 'src/freshteam/types'
 import { HeadingXLarge, HeadingXXLarge, LabelMedium, PRIMITIVE_COLORS } from '@nilfoundation/ui-kit'
 import { getPageTitleOverrides, getCommonHeadingOverrides } from './overrides'
 import { useGroupPositionsByDepartments } from './useGroupPositionsByDepartments'
@@ -20,7 +20,7 @@ import { Position } from './Position/Position'
 import uniq from 'lodash.uniq'
 
 type OpenPositionsProps = {
-  jobsPostings: UIPosition[]
+  jobsPostings: UIPositionWithoutDescription[]
 }
 
 const departmensOrder = ['Engineering', 'Developer Relations', 'Marketing', 'Human Resources']

--- a/site/src/components/pages/OpenPositions/Position/Position.tsx
+++ b/site/src/components/pages/OpenPositions/Position/Position.tsx
@@ -1,11 +1,11 @@
 import { Card } from 'components/Card'
 import s from './Position.module.scss'
-import { UIPosition } from 'src/freshteam/types'
+import { UIPositionWithoutDescription } from 'src/freshteam/types'
 import { HeadingXLarge, LabelMedium, PRIMITIVE_COLORS } from '@nilfoundation/ui-kit'
 import { labelOverrides, titleOverrides } from './overrides'
 
 type PositionProps = {
-  position: UIPosition
+  position: UIPositionWithoutDescription
 }
 
 export const Position = ({ position: { id, remote, type, title, plainTextDescription } }: PositionProps) => {

--- a/site/src/components/pages/OpenPositions/useFilterPositions.ts
+++ b/site/src/components/pages/OpenPositions/useFilterPositions.ts
@@ -1,7 +1,7 @@
-import { UIPosition } from 'src/freshteam/types'
+import { UIPositionWithoutDescription } from 'src/freshteam/types'
 import { PositionsFilter } from './types'
 
-export const useFilterPositions = (positions: UIPosition[], filter: PositionsFilter) => {
+export const useFilterPositions = (positions: UIPositionWithoutDescription[], filter: PositionsFilter) => {
   const filteredPositions = positions.filter((position) => {
     const titleFilter = filter.title ? position.title.toLowerCase().includes(filter.title.toLowerCase()) : true
     const departmentFilter = filter.department

--- a/site/src/components/pages/OpenPositions/useGroupPositionsByDepartments.ts
+++ b/site/src/components/pages/OpenPositions/useGroupPositionsByDepartments.ts
@@ -1,7 +1,10 @@
 import { useMemo } from 'react'
-import { UIPosition } from 'src/freshteam/types'
+import { UIPositionWithoutDescription } from 'src/freshteam/types'
 
-export const useGroupPositionsByDepartments = (positions: UIPosition[], order?: Array<UIPosition['department']>) => {
+export const useGroupPositionsByDepartments = (
+  positions: UIPositionWithoutDescription[],
+  order?: Array<UIPositionWithoutDescription['department']>,
+) => {
   return useMemo(() => {
     const departments = positions.reduce((acc, position) => {
       const department = position.department
@@ -11,7 +14,7 @@ export const useGroupPositionsByDepartments = (positions: UIPosition[], order?: 
         ...acc,
         [department]: [...departmentPositions, position],
       }
-    }, {} as Record<string, UIPosition[]>)
+    }, {} as Record<string, UIPositionWithoutDescription[]>)
 
     if (order) {
       const orderedDepartments = order
@@ -21,7 +24,7 @@ export const useGroupPositionsByDepartments = (positions: UIPosition[], order?: 
             ...acc,
             [department]: departments[department],
           }
-        }, {} as Record<string, UIPosition[]>)
+        }, {} as Record<string, UIPositionWithoutDescription[]>)
 
       return { ...orderedDepartments, ...departments }
     }

--- a/site/src/freshteam/api.ts
+++ b/site/src/freshteam/api.ts
@@ -1,11 +1,11 @@
 import { client } from './client'
 import { mapPositionToUIPosition } from './mappers'
-import { PositionStatus, UIPosition } from './types'
+import { Position, PositionStatus, UIPosition, UIPositionWithoutDescription } from './types'
 
 const USE_MOCK = !!process.env.USE_MOCK || false
 
 class Api {
-  public async getJobPostings(status?: PositionStatus): Promise<UIPosition[]> {
+  public async getJobPostings(status?: PositionStatus): Promise<UIPositionWithoutDescription[]> {
     if (USE_MOCK) {
       return []
     }
@@ -16,9 +16,9 @@ class Api {
       url += `?status=${status}`
     }
 
-    const result = await client.get(url).then((res) => res)
+    const result = await client.get<Position[]>(url).then((res) => res)
 
-    return result.data.map(mapPositionToUIPosition)
+    return result.data.map((x) => mapPositionToUIPosition(x, false))
   }
   public async getJobPosting(id: string): Promise<UIPosition | null> {
     if (USE_MOCK) {
@@ -27,7 +27,7 @@ class Api {
 
     const result = await client.get(`job_postings/${id}`).then((res) => res)
 
-    return mapPositionToUIPosition(result.data)
+    return mapPositionToUIPosition(result.data, true)
   }
   public async getAllPositionPages(): Promise<number[]> {
     if (USE_MOCK) {

--- a/site/src/freshteam/mappers.ts
+++ b/site/src/freshteam/mappers.ts
@@ -1,17 +1,17 @@
-import { Position, UIPosition } from './types'
+import { Position, UIPosition, UIPositionWithoutDescription } from './types'
 import { convert } from 'html-to-text'
 
-export const mapPositionToUIPosition = (position: Position): UIPosition => {
+export const mapPositionToUIPosition = <T extends boolean>(position: Position, includeDescription: T) => {
   return {
     id: position.id,
     title: position.title,
-    description: position.description,
+    description: includeDescription ? position.description : undefined,
     plainTextDescription: convert(position.description, { wordwrap: false, limits: { maxBaseElements: 200 } }),
     remote: position.remote,
     type: mapTypeToDisplayType(position.type),
     branch: position.branch,
     department: position.department.name,
-  }
+  } as T extends true ? UIPosition : UIPositionWithoutDescription
 }
 
 const mapTypeToDisplayType = (type: Position['type']): string => {

--- a/site/src/freshteam/types.ts
+++ b/site/src/freshteam/types.ts
@@ -61,3 +61,5 @@ export interface UIPosition {
   branch: Branch
   department: string
 }
+
+export type UIPositionWithoutDescription = Omit<UIPosition, 'description'>

--- a/site/src/pages/careers/jobs/index.tsx
+++ b/site/src/pages/careers/jobs/index.tsx
@@ -1,17 +1,32 @@
 import MetaLayout from 'components/MetaLayout/MetaLayout'
-import OpenPositions from 'pages/OpenPositions'
+import OpenPositions, { PositionPage } from 'pages/OpenPositions'
 import { REVALIDATE } from 'constants/common'
 import { getSiteConfig } from 'src/strapi'
 
 import { jobsSeoData } from 'stubs/careersPageData'
 import { api } from 'src/freshteam'
 import { InferGetStaticPropsType } from 'next'
+import { useRouter } from 'next/router'
+import NotFound from 'pages/NotFound'
 
-const OpenPositionsPage = ({ jobsPostings }: InferGetStaticPropsType<typeof getStaticProps>) => (
+const OpenPositionsPage = ({ jobsPostings }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const {query} = useRouter()
+  const jobId = query.jobId
+  const jobToDisplay = jobsPostings.find(x => x.id.toString() === jobId)
+
+  if (query.jobId) {
+    return (
+      <MetaLayout seo={jobsSeoData}>
+        {jobToDisplay ? <PositionPage position={jobToDisplay} /> : <NotFound />}
+      </MetaLayout>
+    )
+  }
+
+  return (
   <MetaLayout seo={jobsSeoData}>
     <OpenPositions jobsPostings={jobsPostings} />
   </MetaLayout>
-)
+)}
 
 export async function getStaticProps() {
   const getConfig = getSiteConfig

--- a/site/src/pages/careers/jobs/index.tsx
+++ b/site/src/pages/careers/jobs/index.tsx
@@ -1,33 +1,17 @@
 import MetaLayout from 'components/MetaLayout/MetaLayout'
-import OpenPositions, { PositionPage } from 'pages/OpenPositions'
+import OpenPositions from 'pages/OpenPositions'
 import { REVALIDATE } from 'constants/common'
 import { getSiteConfig } from 'src/strapi'
 
 import { jobsSeoData } from 'stubs/careersPageData'
 import { api } from 'src/freshteam'
 import { InferGetStaticPropsType } from 'next'
-import { useRouter } from 'next/router'
-import NotFound from 'pages/NotFound'
 
-const OpenPositionsPage = ({ jobsPostings }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const { query } = useRouter()
-  const jobId = query.jobId
-  const jobToDisplay = jobsPostings.find((x) => x.id.toString() === jobId)
-
-  if (query.jobId) {
-    return (
-      <MetaLayout seo={jobsSeoData}>
-        {jobToDisplay ? <PositionPage position={jobToDisplay} /> : <NotFound />}
-      </MetaLayout>
-    )
-  }
-
-  return (
-    <MetaLayout seo={jobsSeoData}>
-      <OpenPositions jobsPostings={jobsPostings} />
-    </MetaLayout>
-  )
-}
+const OpenPositionsPage = ({ jobsPostings }: InferGetStaticPropsType<typeof getStaticProps>) => (
+  <MetaLayout seo={jobsSeoData}>
+    <OpenPositions jobsPostings={jobsPostings} />
+  </MetaLayout>
+)
 
 export async function getStaticProps() {
   const getConfig = getSiteConfig

--- a/site/src/pages/careers/jobs/index.tsx
+++ b/site/src/pages/careers/jobs/index.tsx
@@ -10,9 +10,9 @@ import { useRouter } from 'next/router'
 import NotFound from 'pages/NotFound'
 
 const OpenPositionsPage = ({ jobsPostings }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const {query} = useRouter()
+  const { query } = useRouter()
   const jobId = query.jobId
-  const jobToDisplay = jobsPostings.find(x => x.id.toString() === jobId)
+  const jobToDisplay = jobsPostings.find((x) => x.id.toString() === jobId)
 
   if (query.jobId) {
     return (
@@ -23,10 +23,11 @@ const OpenPositionsPage = ({ jobsPostings }: InferGetStaticPropsType<typeof getS
   }
 
   return (
-  <MetaLayout seo={jobsSeoData}>
-    <OpenPositions jobsPostings={jobsPostings} />
-  </MetaLayout>
-)}
+    <MetaLayout seo={jobsSeoData}>
+      <OpenPositions jobsPostings={jobsPostings} />
+    </MetaLayout>
+  )
+}
 
 export async function getStaticProps() {
   const getConfig = getSiteConfig


### PR DESCRIPTION
Use query params to add compatibility with old positions urls, like https://nil.foundation/careers/jobs?jobId=LvfuxuZlE7XG
Also, this diff speeds up page generation in build time and in runtime by reducing size of data passed to the page by adding `includeDescription` mapper param to remove description from api call result (which is the only property that contains a lot of text). We don't need full description in the page of all jobs list.