### PR TITLE
Use br tag as 32px space

### DIFF
--- a/site/src/components/pages/OpenJobs/JobPage/Styles.module.scss
+++ b/site/src/components/pages/OpenJobs/JobPage/Styles.module.scss
@@ -57,6 +57,7 @@
     }
 
     br {
-        display: none;
+        visibility: hidden;
+        margin-top: 32px;
     }
 }


### PR DESCRIPTION
This diff keeps `<br>` tag invisible, but provides margin. The editor in freshteam creates `<br>` tag from new lines. It would be convenient to edit job descriptions with `<br>` serving as a space.