### PR TITLE
Fix grid-column syntax

### DIFF
--- a/site/src/components/common/Footer/Footer.module.scss
+++ b/site/src/components/common/Footer/Footer.module.scss
@@ -94,7 +94,7 @@
 }
 
 .socials {
-  grid-column: span 2 / 4;
+  grid-column: 2 / 4;
   margin-left: size(2);
 
   @include mobile {


### PR DESCRIPTION
CSS Grid does not allow combining the 'span' syntax with explicit line references. This violates the specification and can result in unpredictable grid behavior in browsers. The fix is necessary for proper rendering and standards compliance.
