### PR TITLE
Fix grid-column and background syntax in Error.module.scss

### DIFF
--- a/site/src/components/pages/Error/Error.module.scss
+++ b/site/src/components/pages/Error/Error.module.scss
@@ -27,7 +27,7 @@
 }
 
 .background {
-  background: url('/icons/dots.svg'), repeat;
+  background: url('/icons/dots.svg') repeat;
 }
 
 .arrow {

--- a/site/src/components/pages/Error/Error.module.scss
+++ b/site/src/components/pages/Error/Error.module.scss
@@ -23,7 +23,7 @@
 }
 
 .content {
-  grid-column: span 4 / 6;
+  grid-column: span 2 / 6;
 }
 
 .background {


### PR DESCRIPTION
1. Corrected `grid-column` value: Changed from `span 4 / 6` to `span 2 / 6` for better layout consistency.

2. Fixed `background` syntax: Removed an incorrect comma and applied the proper syntax `background: url('/icons/dots.svg') repeat;`