### PR TITLE
Add privacy policy + fix for bigint conversion

### DIFF
--- a/site/src/components/common/Footer/Footer.module.scss
+++ b/site/src/components/common/Footer/Footer.module.scss
@@ -215,3 +215,8 @@
     height: size(18);
   }
 }
+
+
+.registerNumber {
+  color: #909090;
+}

--- a/site/src/components/common/Footer/Footer.tsx
+++ b/site/src/components/common/Footer/Footer.tsx
@@ -84,7 +84,10 @@ function Footer({ className }: InferProps<typeof Footer.propTypes>) {
         </div>
 
         <div className={s.bottom}>
-          <div className={s.copyright}>© All rights reserved. =nil; Foundation {getYear} | <span className={s.registerNumber}>nil LLC reg. number 389585</span></div>
+          <div className={s.copyright}>
+            © All rights reserved. =nil; Foundation {getYear} |{' '}
+            <span className={s.registerNumber}>nil LLC reg. number 389585</span>
+          </div>
           <Button className={s.arrow} onClick={scrollTop}>
             <Icon name="arrow-up" />
           </Button>

--- a/site/src/components/common/Footer/Footer.tsx
+++ b/site/src/components/common/Footer/Footer.tsx
@@ -84,7 +84,7 @@ function Footer({ className }: InferProps<typeof Footer.propTypes>) {
         </div>
 
         <div className={s.bottom}>
-          <div className={s.copyright}>© All rights reserved. =nil; Foundation {getYear}</div>
+          <div className={s.copyright}>© All rights reserved. =nil; Foundation {getYear} | <span className={s.registerNumber}>nil LLC reg. number 389585</span></div>
           <Button className={s.arrow} onClick={scrollTop}>
             <Icon name="arrow-up" />
           </Button>

--- a/site/src/components/common/Footer/stub.ts
+++ b/site/src/components/common/Footer/stub.ts
@@ -22,6 +22,7 @@ export const stub = {
         },
         { name: 'About', link: '/about' },
         { name: 'Conference Game General T&C', link: '/pages/devcon_game_tc' },
+        { name: 'Privacy policy', link: '/pages/privacy-policy' },
         // TODO: return after create this page
         // { name: 'Glossary', link: '/glossary' },
       ],

--- a/site/src/pages/api/uniswap/swap.ts
+++ b/site/src/pages/api/uniswap/swap.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       params: [fromToken.toUpperCase(), toToken.toUpperCase(), toHex(wei)],
     })
 
-    const expectedInWei = BigInt(Math.round((quote * slippage)))
+    const expectedInWei = BigInt(Math.round(quote * slippage))
 
     const hash = await loadClient.request({
       method: 'nilloadgen_callSwap',

--- a/site/src/pages/api/uniswap/swap.ts
+++ b/site/src/pages/api/uniswap/swap.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       params: [fromToken.toUpperCase(), toToken.toUpperCase(), toHex(wei)],
     })
 
-    const expectedInWei = BigInt((quote * slippage).toString())
+    const expectedInWei = BigInt(Math.round((quote * slippage)))
 
     const hash = await loadClient.request({
       method: 'nilloadgen_callSwap',


### PR DESCRIPTION
This pull request includes several updates to the footer component and an adjustment to the API handler for Uniswap swaps. The changes enhance the footer's content and styling and correct the calculation in the API handler.

### Footer component updates:

* [`site/src/components/common/Footer/Footer.tsx`](diffhunk://#diff-6ba61aed108b185afe4a428a727c75c99d82d13f308565af88aa7b61700e6e06L87-R87): Updated the footer to include the registration number "nil LLC reg. number 389585" next to the copyright text.
* [`site/src/components/common/Footer/stub.ts`](diffhunk://#diff-00dee369d36dd24c1770ffeced0f2f8b17aa43e61d51e4901f1006e8eb878a55R25): Added a new link to the privacy policy page in the footer's navigation links.

### API handler update:

* [`site/src/pages/api/uniswap/swap.ts`](diffhunk://#diff-41d70a10d578e07f4a6c5e7836170ebf3446804d405cd3b536557597fb7b4e2cL22-R22): Corrected the calculation of `expectedInWei` by using `Math.round` to ensure accurate rounding of the quote multiplied by slippage.