### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/build_admin.yaml
+++ b/.github/workflows/build_admin.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/build_site.yaml
+++ b/.github/workflows/build_site.yaml
@@ -8,7 +8,7 @@ jobs:
       USE_MOCK: 1
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected