### PR TITLE
ci: bump setup-node to v4

### DIFF
--- a/.github/workflows/build_admin.yaml
+++ b/.github/workflows/build_admin.yaml
@@ -12,7 +12,7 @@ jobs:
       with:
         version: 10
     - name: Setup Nodejs
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
     - name: Install dependencies

--- a/.github/workflows/build_site.yaml
+++ b/.github/workflows/build_site.yaml
@@ -14,7 +14,7 @@ jobs:
       with:
         version: 10
     - name: Setup Nodejs
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with: 
         node-version: 18.x
     - name: Install dependencies


### PR DESCRIPTION
Maintenance update to setup-node@v4 to align with the current best practices; nothing else modified. Refer to [v4.0.0 release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0) for details.